### PR TITLE
Fixes necessary to get a development setup running

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@ Measure Calculation Tool for reporting and calculating FHIR-based digital qualit
 #### Pre-requisities
 - NodeJs version 18 is required
 - Docker is required
+- At least 8 GB RAM is required
+  - If running Docker through a virtual machine (e.g. using Docker Desktop or Colima), ensure the this RAM is allocated to the virtual machine.
 
 #### Steps
-1. Run script `./setup_app_files` to prep data files
-2. Standup services with `docker-compose build backend && docker-compose up` and wait 1 minute before proceeding to next step
-3. Load data with `./load-local-data.sh`
+1. Run script `./bin/setup_app_files.sh` to prep data files
+2. Standup services with `docker-compose up --build` and wait 1 minute before proceeding to next step
+3. Load data with `./bin/load-local-data.sh`
 4. go to `frontend` directory and run `yarn install && yarn start`
 5. Wait until `http://localhost:8088` loads with `Whitelabel Error` message
 6. Navigate to app at `http://localhost:3000`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,10 +11,10 @@ services:
     ports:
       - 8088:8088
   cqf-ruler-a:
-    image: alphora/cqf-ruler:vsm_draft_operation 
+    image: alphora/cqf-ruler
     ports:
       - 8080:8080
   cqf-ruler-b:
-    image: alphora/cqf-ruler:vsm_draft_operation 
+    image: alphora/cqf-ruler
     ports:
       - 8082:8080

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -17,4 +17,4 @@ export const baseUrl =
   process.env.NODE_ENV === 'development'
     ? 'http://localhost:8088'
     : 'http://a913da9435453489fb73187d9b16edc5-1641411053.us-east-1.elb.amazonaws.com';
-export const cqfServerUrl = process.env.NODE_ENV === 'development' ? 'http://cqf-ruler:8080' : 'http://mct-cqf-ruler';
+export const cqfServerUrl = process.env.NODE_ENV === 'development' ? 'http://cqf-ruler-a:8080' : 'http://mct-cqf-ruler';

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -60,6 +60,12 @@
 			<version>${hapi.version}</version>
 		</dependency>
 		<dependency>
+			<!-- force 5.6.76 to get the fix to https://github.com/hapifhir/org.hl7.fhir.core/issues/961 -->
+			<groupId>ca.uhn.hapi.fhir</groupId>
+			<artifactId>org.hl7.fhir.utilities</artifactId>
+			<version>5.6.76</version>
+		</dependency>
+		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
 			<version>${javax.version}</version>
@@ -88,7 +94,7 @@
 		<dependency>
 			<groupId>info.cqframework</groupId>
 			<artifactId>engine-jackson</artifactId>
-			<version>2.6.0-SNAPSHOT</version>
+			<version>2.6.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>


### PR DESCRIPTION
* Fix some commands and document RAM requirements in the README.
* Fix reference to a nonexistent (or since-deleted?) version of cqf-ruler in docker-compose.yml.
* Fix a URL in frontend/src/config.js to match Docker configuration.
* Fix some versions in java/pom.xml.